### PR TITLE
Fix CSS syntax issues

### DIFF
--- a/apps/teste/app/globals.css
+++ b/apps/teste/app/globals.css
@@ -2,7 +2,6 @@
 @import "@repo/tailwind-config";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
 
 :root {
   --foreground-rgb: 0, 0, 0;
@@ -50,7 +49,7 @@
   }
 }
 
-@theme inline {
+:root {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -124,9 +123,11 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    border-color: var(--border);
+    outline-color: var(--ring);
   }
   body {
-    @apply bg-background text-foreground;
+    background-color: var(--background);
+    color: var(--foreground);
   }
 }

--- a/packages/tailwind-config/shared-styles.css
+++ b/packages/tailwind-config/shared-styles.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@theme {
+:root {
   --color-blue-1000: #2a8af6;
   --color-purple-1000: #a853ba;
   --color-red-1000: #e92a67;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,2 +1,4 @@
 /* Component-level styles for the UI package */
-@import "tailwindcss" prefix(ui);
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,0 +1,5 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  prefix: 'ui-',
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+};


### PR DESCRIPTION
## Summary
- replace unsupported Tailwind import with standard directives
- move shared color variables into `:root`
- convert advanced directives in app global styles
- add Tailwind config to prefix UI classes

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6887fecc0194832186ac028fea490d3d