### PR TITLE
Fix Tailwind directives in UI package

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,4 +1,4 @@
 /* Component-level styles for the UI package */
-@tailwind base;
-@tailwind components;
+/* Tailwind v4 directives */
+@import "tailwindcss/preflight";
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- update Tailwind CSS directives in `packages/ui/src/styles.css` for Tailwind v4 compatibility

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688801d515988321a93b770a15d86d30