### PR TITLE
Fix Tailwind directive lint warning

### DIFF
--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -1,4 +1,6 @@
 /* Component-level styles for the UI package */
 /* Tailwind v4 directives */
 @import "tailwindcss/preflight";
-@tailwind utilities;
+/* Using the import form keeps CSS linters from flagging the Tailwind
+   utilities directive as an unknown at-rule. */
+@import "tailwindcss/utilities";


### PR DESCRIPTION
## Summary
- fix linter error in `packages/ui/src/styles.css`

## Testing
- `pnpm lint`
- `pnpm run check-types` *(fails: Module './sidebars/diascorp-sidebar' has no exported member 'SidebarDiasCorp')*

------
https://chatgpt.com/codex/tasks/task_e_6888067f288883218f1f5973fe61f444